### PR TITLE
Correctly search for nim in PATH

### DIFF
--- a/pkg/nim/nim.go
+++ b/pkg/nim/nim.go
@@ -48,7 +48,7 @@ func Version() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	stdout, stderr, err := nimCmd(cwd, []string{}, []string{"--version"})
+	stdout, stderr, err := nimCmd(cwd, os.Environ(), []string{"--version"})
 	if err != nil {
 		return string(stderr), err
 	}


### PR DESCRIPTION
This fixes a bug where denim could not find nim in PATH, even if it correctly is setup.